### PR TITLE
Supporting java.net.preferIPv4Stack & java.net.preferIPv6Addresses JVM Properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.idea
+*.iml
+target/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-*.idea
+.idea/
 *.iml
-target/*
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.google.code.jain-sip-rfc3263-router</groupId>
 	<artifactId>jain-sip-rfc3263-router</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.3-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>JAIN-SIP RFC3263 Router</name>
 	<url>http://code.google.com/p/jain-sip-rfc3263-router/</url>
 	<parent>
@@ -72,8 +72,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -87,6 +87,14 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/google/code/rfc3263/dns/ServiceRecordSelector.java
+++ b/src/main/java/com/google/code/rfc3263/dns/ServiceRecordSelector.java
@@ -1,13 +1,13 @@
 package com.google.code.rfc3263.dns;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
+import com.google.code.rfc3263.dns.sorter.ServiceRecordWeightSorter;
 import net.jcip.annotations.ThreadSafe;
 
 import org.apache.log4j.Logger;
@@ -17,32 +17,32 @@ import org.xbill.DNS.SRVRecord;
  * This class is used for sorting ServiceRecords.
  * <p>
  * This class groups each ServiceRecord according to its priority into a TreeMap (indexed
- * by priority), and then sorts each group by weight, and then by target name. 
+ * by priority), and then sorts each group by weight, and then by target name.
  */
 @ThreadSafe
 public class ServiceRecordSelector {
 	private final Logger LOGGER = Logger.getLogger(ServiceRecordSelector.class);
 	private final List<SRVRecord> services;
-	private final Comparator<SRVRecord> weightingComparator;
-	
-	public ServiceRecordSelector(List<SRVRecord> services, Comparator<SRVRecord> weightingComparator) {
+	private final ServiceRecordWeightSorter weightingSorter;
+
+	public ServiceRecordSelector(List<SRVRecord> services, ServiceRecordWeightSorter weightingSorter) {
 		this.services = new LinkedList<SRVRecord>(services);
-		this.weightingComparator = weightingComparator;
+		this.weightingSorter = weightingSorter;
 	}
-	
+
 	public List<SRVRecord> select() {
 		final List<SRVRecord> sortedList = new LinkedList<SRVRecord>();
 		LOGGER.debug("Sorting SRV records");
-		
+
 		if (services.size() == 1) {
 			LOGGER.debug("One SRV record found, no sort required");
 			sortedList.addAll(services);
 		} else {
 			LOGGER.debug("Multiple SRV records found, sorting by SRV priority field");
 			Collections.sort(this.services, new ServiceRecordPriorityComparator());
-			
+
 			// Split map into priorities.
-			final Map<Integer, List<SRVRecord>> priorityMap = new TreeMap<Integer, List<SRVRecord>>(); 
+			final Map<Integer, List<SRVRecord>> priorityMap = new TreeMap<Integer, List<SRVRecord>>();
 			for (SRVRecord service : this.services) {
 				if (priorityMap.containsKey(service.getPriority()) == false) {
 					priorityMap.put(service.getPriority(), new LinkedList<SRVRecord>());
@@ -53,22 +53,23 @@ public class ServiceRecordSelector {
 			for (Entry<Integer, List<SRVRecord>> entry : priorityMap.entrySet()) {
 				final Integer priority = entry.getKey();
 				final List<SRVRecord> priorityList = entry.getValue();
-				
+
 				if (LOGGER.isDebugEnabled()) {
 					LOGGER.debug("Sorting SRV records for priority field value " + priority);
 				}
 				if (priorityList.size() != 1) {
 					if (LOGGER.isDebugEnabled()) {
-						LOGGER.debug("Multiple SRV records found at priority " + priority + ", using " + weightingComparator.getClass() + " as sorting algorithm");
+						LOGGER.debug("Multiple SRV records found at priority " + priority + ", using " + weightingSorter.getClass() + " as sorting algorithm");
 					}
-					Collections.sort(priorityList, weightingComparator);
+					weightingSorter.sort(priorityList);
 				} else if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("One SRV record found at priority " + priority + ", no further sort required");
+					LOGGER.debug("One SRV record found at priority " + priority
+							+ ", no further sort required");
 				}
 				sortedList.addAll(priorityList);
 			}
 		}
-		
+
 		LOGGER.debug("Finished sorting SRV records");
 		return sortedList;
 	}

--- a/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordDeterministicWeightSorter.java
+++ b/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordDeterministicWeightSorter.java
@@ -1,0 +1,25 @@
+package com.google.code.rfc3263.dns.sorter;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.xbill.DNS.SRVRecord;
+
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class ServiceRecordDeterministicWeightSorter implements ServiceRecordWeightSorter {
+
+	private Comparator<SRVRecord> weightComparator;
+
+	public ServiceRecordDeterministicWeightSorter(Comparator<SRVRecord> weightComparator) {
+		this.weightComparator = weightComparator;
+	}
+
+	@Override
+	public void sort(List<SRVRecord> srvRecords) {
+		Collections.sort(srvRecords, weightComparator);
+	}
+
+}

--- a/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordLoadBalanceWeightSorter.java
+++ b/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordLoadBalanceWeightSorter.java
@@ -1,0 +1,85 @@
+package com.google.code.rfc3263.dns.sorter;
+
+import java.util.*;
+
+import org.xbill.DNS.SRVRecord;
+
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class ServiceRecordLoadBalanceWeightSorter implements ServiceRecordWeightSorter {
+
+	private static final int FIRST_ELEMENT_POSITION = 0;
+
+	private final Random random = new Random();
+	private final Comparator<SRVRecord> weightComparator = new WeightComparator();
+
+	public ServiceRecordLoadBalanceWeightSorter() {
+	}
+
+	@Override
+	/**
+	 * Algorithm from RFC 2782
+	 *
+	 *         To select a target to be contacted next, arrange all SRV RRs
+	 *         (that have not been ordered yet) in any order, except that all
+	 *         those with weight 0 are placed at the beginning of the list.
+	 *
+	 *         Compute the sum of the weights of those RRs, and with each RR
+	 *         associate the running sum in the selected order. Then choose a
+	 *         uniform random number between 0 and the sum computed
+	 *         (inclusive), and select the RR whose running sum value is the
+	 *         first in the selected order which is greater than or equal to
+	 *         the random number selected. The target host specified in the
+	 *         selected SRV RR is the next one to be contacted by the client.
+	 *         Remove this SRV RR from the set of the unordered SRV RRs and
+	 *         apply the described algorithm to the unordered SRV RRs to select
+	 *         the next target host.  Continue the ordering process until there
+	 *         are no unordered SRV RRs.
+	 */
+	public void sort(List<SRVRecord> srvRecords) {
+		Collections.sort(srvRecords, weightComparator);
+		loadBalanceSortBasedOnWeight(srvRecords);
+	}
+
+	private void loadBalanceSortBasedOnWeight(List<SRVRecord> srvRecords) {
+		for(int i = 0; i < srvRecords.size(); i++) {
+			List<SRVRecord> unorderedRecords = srvRecords.subList(i, srvRecords.size());
+			int randomValue = generateRandom(getTotalWeight(unorderedRecords) + 1);
+			int cumulativeWeight = 0;
+			for (SRVRecord srvRecord : unorderedRecords) {
+				cumulativeWeight += srvRecord.getWeight();
+				if (randomValue <= cumulativeWeight) {
+					srvRecords.remove(srvRecord);
+					srvRecords.add(i, srvRecord);
+					break;
+				}
+			}
+		}
+	}
+
+	private int getTotalWeight(List<SRVRecord> srvRecords) {
+		int totalWeight = 0;
+		for (SRVRecord srvRecord : srvRecords) {
+			totalWeight += srvRecord.getWeight();
+		}
+		return totalWeight;
+	}
+
+	public int generateRandom(int bound) {
+		if (bound <= 0) {
+			return 0;
+		} else {
+			return random.nextInt(bound);
+		}
+	}
+
+	/**
+	 * Ascending sort of SRVRecord based on weight to ensure records with weight of 0 are first
+	 */
+	private static class WeightComparator implements Comparator<SRVRecord> {
+		public int compare(SRVRecord o1, SRVRecord o2) {
+			return (o1.getWeight() < o2.getWeight()) ? -1 : ((o1.getWeight() == o2.getWeight()) ? 0 : 1);
+		}
+	}
+}

--- a/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordLoadBalanceWeightSorter.java
+++ b/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordLoadBalanceWeightSorter.java
@@ -11,7 +11,7 @@ public class ServiceRecordLoadBalanceWeightSorter implements ServiceRecordWeight
 
 	private static final int FIRST_ELEMENT_POSITION = 0;
 
-	private final Random random = new Random();
+	private final SplittableRandom random = new SplittableRandom();
 	private final Comparator<SRVRecord> weightComparator = new WeightComparator();
 
 	public ServiceRecordLoadBalanceWeightSorter() {

--- a/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordWeightSorter.java
+++ b/src/main/java/com/google/code/rfc3263/dns/sorter/ServiceRecordWeightSorter.java
@@ -1,0 +1,11 @@
+package com.google.code.rfc3263.dns.sorter;
+
+import java.util.List;
+
+import org.xbill.DNS.SRVRecord;
+
+public interface ServiceRecordWeightSorter {
+
+	public void sort(List<SRVRecord> srvRecords);
+
+}

--- a/src/test/java/com/google/code/rfc3263/LocatorTest.java
+++ b/src/test/java/com/google/code/rfc3263/LocatorTest.java
@@ -48,6 +48,7 @@ public class LocatorTest {
 	public void setUp() throws PeerUnavailableException {
 		addressFactory = SipFactory.getInstance().createAddressFactory();
 		resolver = createMock(Resolver.class);
+		System.setProperty("java.net.preferIPv4Stack", "false");
 	}
 	
 	@After
@@ -354,6 +355,19 @@ public class LocatorTest {
 
 		SipURI uri = addressFactory.createSipURI(null, "example.org");
 		
+		Locator locator = new Locator(Collections.singletonList("UDP"), resolver);
+		locator.locate(uri);
+	}
+
+	@Test
+	public void testShouldNotLookupAAAAWhenPreferIPv4StackEnabled() throws ParseException, IOException {
+		System.setProperty("java.net.preferIPv4Stack", "true");
+		expect(resolver.lookupARecords(new Name("example.org."))).andReturn(new HashSet<ARecord>());
+		replay(resolver);
+
+		SipURI uri = addressFactory.createSipURI(null, "example.org");
+		uri.setPort(5060);
+
 		Locator locator = new Locator(Collections.singletonList("UDP"), resolver);
 		locator.locate(uri);
 	}

--- a/src/test/java/com/google/code/rfc3263/dns/ServiceRecordSelectorTest.java
+++ b/src/test/java/com/google/code/rfc3263/dns/ServiceRecordSelectorTest.java
@@ -1,10 +1,15 @@
 package com.google.code.rfc3263.dns;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.google.code.rfc3263.dns.sorter.ServiceRecordDeterministicWeightSorter;
+import com.google.code.rfc3263.dns.sorter.ServiceRecordLoadBalanceWeightSorter;
 import org.junit.Test;
 import org.xbill.DNS.DClass;
 import org.xbill.DNS.Name;
@@ -14,53 +19,127 @@ import org.xbill.DNS.TextParseException;
 public class ServiceRecordSelectorTest {
 	/**
 	 * Tests four records, all with the same weight.
-	 * @throws TextParseException 
+	 * @throws TextParseException
 	 */
 	@Test
 	public void testSelectByTarget() throws TextParseException {
 		List<SRVRecord> services = new ArrayList<SRVRecord>();
-		
+
 		SRVRecord a = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 0, 5060, new Name("a.sip.example.org."));
 		SRVRecord b = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 0, 5060, new Name("b.sip.example.org."));
 		SRVRecord c = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 0, 5060, new Name("c.sip.example.org."));
 		SRVRecord d = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 0, 5060, new Name("d.sip.example.org."));
-		
+
 		services.add(b);
 		services.add(c);
 		services.add(d);
 		services.add(a);
-		
-		ServiceRecordSelector selector = new ServiceRecordSelector(services, new ServiceRecordDeterministicComparator());
+
+		ServiceRecordSelector selector = new ServiceRecordSelector(services, new ServiceRecordDeterministicWeightSorter(new ServiceRecordDeterministicComparator()));
 		List<SRVRecord> sortedServices = selector.select();
 		assertEquals(a, sortedServices.get(0));
 		assertEquals(b, sortedServices.get(1));
 		assertEquals(c, sortedServices.get(2));
 		assertEquals(d, sortedServices.get(3));
 	}
-	
+
 	/**
 	 * Tests four records, all with the different weights.
-	 * @throws TextParseException 
+	 * @throws TextParseException
 	 */
 	@Test
 	public void testSelectByWeight() throws TextParseException {
 		List<SRVRecord> services = new ArrayList<SRVRecord>();
-		
+
 		SRVRecord a = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 0, 5060, new Name("a.sip.example.org."));
 		SRVRecord b = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 1, 5060, new Name("b.sip.example.org."));
 		SRVRecord c = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 2, 5060, new Name("c.sip.example.org."));
 		SRVRecord d = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 3, 5060, new Name("d.sip.example.org."));
-		
+
 		services.add(b);
 		services.add(d);
 		services.add(c);
 		services.add(a);
-		
-		ServiceRecordSelector selector = new ServiceRecordSelector(services, new ServiceRecordDeterministicComparator());
+
+		ServiceRecordSelector selector = new ServiceRecordSelector(services, new ServiceRecordDeterministicWeightSorter(new ServiceRecordDeterministicComparator()));
 		List<SRVRecord> sortedServices = selector.select();
 		assertEquals(d, sortedServices.get(0));
 		assertEquals(c, sortedServices.get(1));
 		assertEquals(b, sortedServices.get(2));
 		assertEquals(a, sortedServices.get(3));
 	}
+
+	/**
+	 * Tests four records, all with the different weights.
+	 * @throws TextParseException
+	 */
+	@Test
+	public void testSelectLoadBalancedByWeight() throws TextParseException {
+		PositionCount aPositionCount = new PositionCount();
+		PositionCount bPositionCount = new PositionCount();
+		PositionCount cPositionCount = new PositionCount();
+
+		for(int i = 0; i < 10000; i++) {
+			List<SRVRecord> services = new ArrayList<SRVRecord>();
+
+			SRVRecord a = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 30, 5060, new Name("a.sip.example.org."));
+			SRVRecord b = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 15, 5060, new Name("b.sip.example.org."));
+			SRVRecord c = new SRVRecord(new Name("_sip._tcp.example.org."), DClass.IN, 1000L, 1, 0, 5060, new Name("d.sip.example.org."));
+
+			services.add(c);
+			services.add(b);
+			services.add(a);
+
+			ServiceRecordSelector selector = new ServiceRecordSelector(services, new ServiceRecordLoadBalanceWeightSorter());
+			List<SRVRecord> sortedServices = selector.select();
+
+			aPositionCount.increment(sortedServices.indexOf(a));
+			bPositionCount.increment(sortedServices.indexOf(b));
+			cPositionCount.increment(sortedServices.indexOf(c));
+		}
+
+		assertTrue(aPositionCount.getCount(0) < 7000);
+		assertTrue(aPositionCount.getCount(0) > 5000);
+		assertTrue(aPositionCount.getCount(1) < 4500);
+		assertTrue(aPositionCount.getCount(1) > 2500);
+		assertTrue(aPositionCount.getCount(2) < 1000);
+		assertTrue(aPositionCount.getCount(2) > 50);
+
+		assertTrue(bPositionCount.getCount(0) < 4500);
+		assertTrue(bPositionCount.getCount(0) > 2500);
+		assertTrue(bPositionCount.getCount(1) < 7000);
+		assertTrue(bPositionCount.getCount(1) > 5000);
+		assertTrue(bPositionCount.getCount(2) < 1000);
+		assertTrue(bPositionCount.getCount(2) > 50);
+
+		assertTrue(cPositionCount.getCount(0) < 300);
+		assertTrue(cPositionCount.getCount(0) > 50);
+		assertTrue(cPositionCount.getCount(1) < 1000);
+		assertTrue(cPositionCount.getCount(1) > 50);
+		assertTrue(cPositionCount.getCount(2) < 9900);
+		assertTrue(cPositionCount.getCount(2) > 8500);
+	}
+
+	private static class PositionCount {
+		Map<Integer, Integer> counts = new HashMap<Integer, Integer>();
+
+		public void increment(int position) {
+			Integer currentCount = counts.get(position);
+			if(currentCount == null) {
+				currentCount = 0;
+			}
+			currentCount++;
+			counts.put(position, currentCount);
+		}
+
+		public int getCount(int position) {
+			return counts.get(position);
+		}
+
+		@Override
+		public String toString() {
+			return counts.toString();
+		}
+	}
+
 }


### PR DESCRIPTION
Setting java.net.preferIPv4Stack=true removes the query of AAAA records. 
Setting java.net.preferIPv6Addresses=true orders the AAAA records first.

---
Extract from https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html

java.net.preferIPv4Stack (default: false)

- If IPv6 is available on the operating system the underlying native socket will be, by default, an IPv6 socket which lets applications connect to, and accept connections from, both IPv4 and IPv6 hosts. However, in the case an application would rather use IPv4 only sockets, then this property can be set to true. The implication is that it will not be possible for the application to communicate with IPv6 only hosts.

java.net.preferIPv6Addresses (default: false)

- When dealing with a host which has both IPv4 and IPv6 addresses, and if IPv6 is available on the operating system, the default behavior is to prefer using IPv4 addresses over IPv6 ones. This is to ensure backward compatibility, for example applications that depend on the representation of an IPv4 address (e.g. 192.168.1.1). This property can be set to true to change that preference and use IPv6 addresses over IPv4 ones where possible.
